### PR TITLE
Fixed Stripe API issue

### DIFF
--- a/server/models/plugins/stripe-customer.js
+++ b/server/models/plugins/stripe-customer.js
@@ -58,7 +58,7 @@ module.exports = exports = function stripeCustomer (schema, options) {
         user.stripe.customerId = customer.id;
       }
 
-      var card = customer.cards.data[0];
+      var card = customer.sources.data[0];
       user.stripe.last4 = card.last4;
       user.save(function(err){
         if (err) return cb(err);


### PR DESCRIPTION
I received the following error when attempting to change my plan: 

```
C:\workspace\node-stripe-membership-saas-master\server\models\plugins\stripe-customer.js:62
      var card = customer.cards.data[0];
                               ^
TypeError: Cannot read property 'data' of undefined
    at cardHandler (C:\workspace\node-stripe-membership-saas-master\server\models\plugins\stripe-customer.js:62:32)
    at null._onTimeout (C:\workspace\node-stripe-membership-saas-master\node_modules\stripe\lib\StripeResource.js:87:34)
    at Timer.listOnTimeout [as ontimeout] (timers.js:112:15)

C:\workspace\node-stripe-membership-saas-master>
```

The latest Stripe API no longer has a customer.cards object, but now has customer.sources; have changed the code to support this.