### PR TITLE
removed unnecessary save call

### DIFF
--- a/server/models/plugins/stripe-customer.js
+++ b/server/models/plugins/stripe-customer.js
@@ -40,11 +40,7 @@ module.exports = exports = function stripeCustomer (schema, options) {
       if (err) return cb(err);
 
       user.stripe.customerId = customer.id;
-
-      user.save(function(err){
-        if (err) return cb(err);
-        return cb(null);
-      });
+      
     });
   };
 


### PR DESCRIPTION
I stumbled upon a bug in a larger MEAN application.

Basically the createCustomer method is only called in a pre-save hook, so saving the user is useless.

Moreover, by calling the save method, the pre-save hook will be called a second time, potentially causing bugs if other hooks are involved.