### PR TITLE
bump mongoose to latest and remove deprecation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "express-validator": "^2.6.0",
     "lodash": "^2.4.1",
     "middleware-responder": "^1.0.0",
-    "mongoose": "^3.8.16",
+    "mongoose": "^4.2.5",
     "mongoose-timestamp": "^0.3.0",
     "morgan": "~1.3.0",
     "nodemailer": "^1.3.0",


### PR DESCRIPTION
This resolves issue #13 under node v0.12+. Node 0.10 will need to use deprecated versions.