### PR TITLE
update stripe requirement in middleware dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "passport-local": "^1.0.0",
     "serve-favicon": "~2.1.3",
     "stripe": "^3.0.2",
-    "stripe-webhook-middleware": "^0.1.2",
+    "stripe-webhook-middleware": "^0.2.0",
     "swig": "^1.4.2"
   }
 }


### PR DESCRIPTION
fixes weird issue in newer versions of node where node-gyp was required because of jsdom/contextify in old stripe sdk.